### PR TITLE
Chore/fix hover state tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,14 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ Breaking Change
 - 🐞 Bugfix
 
-## Unreleased
+## [0.8.1]
+- 🐞 Tooltip Hover [#60](https://github.com/tenzir/ui-component-library/pull/60)
+The tooltip was included in the hover's bounding box of the element. The 
+`pointer-events` are now disabled for hover events until they become visible, 
+meaning it can only be activated by hovering the element upon which the tooltip
+is introduced, not the tooltip itself.
 
+## [0.8.0]
 - 🧬 Tooltips [#59](https://github.com/tenzir/ui-component-library/pull/59)
 We've used a CSS only approach for tooltips that is reasonably flexible in terms
 of positioning. We'll test this internally before releasing it publicly.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tenzir-ui-component-library",
   "author": "Tenzir",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "scripts": {
     "build:reason": "bsb -clean-world && bsb -make-world",
     "build:storybook": "build-storybook",

--- a/src/Tooltip.re
+++ b/src/Tooltip.re
@@ -161,6 +161,7 @@ let tip = (~theme=UiTypes.light, ~tipPosition=Top(Center), value) => {
           whiteSpace(`nowrap),
           zIndex(999),
           opacity(0.),
+          pointerEvents(`none),
           transitionProperty("all"),
           transitionDuration(200),
           transitionTimingFunction(`easeInOut),
@@ -181,6 +182,7 @@ let tip = (~theme=UiTypes.light, ~tipPosition=Top(Center), value) => {
           borderBottom(8->px, `solid, tooltipBackground),
           zIndex(100),
           opacity(0.),
+          pointerEvents(`none),
           transitionProperty("all"),
           transitionDuration(200),
           transitionTimingFunction(`easeInOut),
@@ -189,8 +191,8 @@ let tip = (~theme=UiTypes.light, ~tipPosition=Top(Center), value) => {
         ],
       ),
       hover([
-        selector("&:before", [opacity(1.)]),
-        selector("&:after", [opacity(1.)]),
+        selector("&:before", [opacity(1.), pointerEvents(`auto)]),
+        selector("&:after", [opacity(1.), pointerEvents(`auto)]),
       ]),
     ])
   );


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description
When hovering, the tooltip's position (even though it was invisible) was still taken into account in the hover bounding box.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
Commit-by-commit

Try starting the storybook and hovering the spot where the tooltip will be, it should not become visible after this PR.