### PR TITLE
Touch up docs / pin dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ yarn start
 
 **Start Storybook server (should be ran simultaniously):**
 ```sh
-yarn storybook
+yarn server
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
       "node_modules/(?!(@glennsl|bs-platform|bs-css)/)"
     ]
   },
+  "resolutions": {
+    "browserslist": "^4.16.5"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -1,52 +1,57 @@
-import React from "react";
-import { make as Input } from "../src/Input.bs.js";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { useDarkMode } from "storybook-dark-mode";
-import { make as Card } from "../src/Card.bs.js";
+import React from 'react'
+import { make as Input } from '../src/Input.bs.js'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { okaidia } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { useDarkMode } from 'storybook-dark-mode'
+import { make as Card } from '../src/Card.bs.js'
 import {
-  labeled,
-  light,
-  dark,
-  normal,
-  mono,
-  valid,
-  invalid,
-} from "../src/UiTypes.bs";
-import { tiny, huge } from "../src/CardStyles.bs";
+    labeled,
+    light,
+    dark,
+    normal,
+    mono,
+    valid,
+    invalid,
+} from '../src/UiTypes.bs'
+import { tiny, huge } from '../src/CardStyles.bs'
 
 export default {
-  title: "Input",
-};
+    title: 'Input',
+}
 
 const margin = {
-  margin: "1rem",
-};
+    margin: '1rem',
+}
 
 export const input = () => {
-  const theme = useDarkMode() ? dark : light;
+    const theme = useDarkMode() ? dark : light
 
-  return (
-    <div style={margin}>
-      <Card theme={theme}>
-        <h1>Input</h1>
+    return (
+        <div style={margin}>
+            <Card theme={theme}>
+                <h1>Input</h1>
 
-        <h3>Interface</h3>
-        <p>
-          As there is the option to have a label, we need to have an id so that
-          we can make that clickable and link the label and the input. We can
-          infer the id from the label, but this may clash. When in doubt, add an
-          id.
-        </p>
-        <SyntaxHighlighter language="reason" style={okaidia} showLineNumbers>
-          {`type Input: (
+                <h3>Interface</h3>
+                <p>
+                    As there is the option to have a label, we need to have an
+                    id so that we can make that clickable and link the label and
+                    the input. We can infer the id from the label, but this may
+                    clash. When in doubt, add an id.
+                </p>
+                <SyntaxHighlighter
+                    language="reason"
+                    style={okaidia}
+                    showLineNumbers
+                >
+                    {`type Input: (
   ~_type: option(string), /* maps to "type", defaults to "text" */
   ~defaultValue: option(string), /* defaults to empty string */
   ~value: option(string),
   ~disabled: option(bool), /* defaults to false */
-  ~label: option(UiStyles.labels), /* defaults to "UiStyles.Unlabeled" */
+  ~label: option(UiTypes.labels), /* defaults to "UiTypes.Unlabeled" */
   ~id: option(string), /* the id is used to make labels clickable. This falls back to the label */
-  ~validity: option(UiStyles.validation), /* defaults to "UiStyles.Valid" */
+  ~validity: option(UiTypes.validation), /* defaults to "UiTypes.Valid" */
+  ~variant: option(UiTypes.fontStyle), /* defaults to "UiTypes.Normal" */
   ~width: option(float), /* as a percentage. Defaults to "100.0" */
   ~theme: option(UiTypes.theme)
   ~placeholder: option(string) /* defaults to empty string */
@@ -54,63 +59,63 @@ export const input = () => {
   ~onBlur=option(React.SyntheticEvent.t->unit),
 ) => React.element;
 `}
-        </SyntaxHighlighter>
+                </SyntaxHighlighter>
 
-        <h3>Preview</h3>
-        <h4>Custom Width</h4>
-        <Input
-          label={labeled("I'm a tiny input")}
-          placeholder="Like for a zipcode"
-          width={10.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Input
-          label={labeled("I'm a bit bigger")}
-          placeholder="Like for a name"
-          width={60.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Input
-          label={labeled("If the total width stays under 100%")}
-          placeholder="We stay inline"
-          width={30.0}
-          theme={theme}
-          variant={normal}
-        />
+                <h3>Preview</h3>
+                <h4>Custom Width</h4>
+                <Input
+                    label={labeled("I'm a tiny input")}
+                    placeholder="Like for a zipcode"
+                    width={10.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Input
+                    label={labeled("I'm a bit bigger")}
+                    placeholder="Like for a name"
+                    width={60.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Input
+                    label={labeled('If the total width stays under 100%')}
+                    placeholder="We stay inline"
+                    width={30.0}
+                    theme={theme}
+                    variant={normal}
+                />
 
-        <h4>Labeled vs Unlabeled</h4>
-        <Input
-          label={labeled("I have a label")}
-          placeholder="Check my cool label above"
-          width={50.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Input
-          placeholder="I don't"
-          width={50.0}
-          theme={theme}
-          variant={normal}
-        />
+                <h4>Labeled vs Unlabeled</h4>
+                <Input
+                    label={labeled('I have a label')}
+                    placeholder="Check my cool label above"
+                    width={50.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Input
+                    placeholder="I don't"
+                    width={50.0}
+                    theme={theme}
+                    variant={normal}
+                />
 
-        <h4>Normal / Mono fonts</h4>
-        <Input
-          label={labeled("Normal Font")}
-          placeholder="Font setting will also have effect in the placeholder"
-          width={50.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Input
-          label={labeled("Mono Font")}
-          placeholder="And in the label"
-          width={50.0}
-          theme={theme}
-          variant={mono}
-        />
-      </Card>
-    </div>
-  );
-};
+                <h4>Normal / Mono fonts</h4>
+                <Input
+                    label={labeled('Normal Font')}
+                    placeholder="Font setting will also have effect in the placeholder"
+                    width={50.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Input
+                    label={labeled('Mono Font')}
+                    placeholder="And in the label"
+                    width={50.0}
+                    theme={theme}
+                    variant={mono}
+                />
+            </Card>
+        </div>
+    )
+}

--- a/stories/slider.stories.js
+++ b/stories/slider.stories.js
@@ -45,7 +45,7 @@ export const Sliders = () => {
                     >
                         {`type Slider: (
   ~theme: option(UiTypes.theme)),
-  ~label: UiStyles.labels, /* defaults to "UiStyles.Unlabeled" */
+  ~label: UiTypes.labels, /* defaults to "UiTypes.Unlabeled" */
   ~min:int, /* defaults to 0 */
   ~max:int, /* defaults to 100 */
   ~value: int,

--- a/stories/textarea.stories.js
+++ b/stories/textarea.stories.js
@@ -1,53 +1,58 @@
-import React from "react";
-import { make as Textarea } from "../src/Textarea.bs.js";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { okaidia } from "react-syntax-highlighter/dist/esm/styles/prism";
-import { useDarkMode } from "storybook-dark-mode";
-import { make as Card } from "../src/Card.bs.js";
+import React from 'react'
+import { make as Textarea } from '../src/Textarea.bs.js'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { okaidia } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { useDarkMode } from 'storybook-dark-mode'
+import { make as Card } from '../src/Card.bs.js'
 import {
-  labeled,
-  light,
-  dark,
-  normal,
-  mono,
-  valid,
-  invalid,
-} from "../src/UiTypes.bs";
-import { both, horizontal, vertical } from "../src/TextareaStyles.bs";
-import { tiny, huge } from "../src/CardStyles.bs";
+    labeled,
+    light,
+    dark,
+    normal,
+    mono,
+    valid,
+    invalid,
+} from '../src/UiTypes.bs'
+import { both, horizontal, vertical } from '../src/TextareaStyles.bs'
+import { tiny, huge } from '../src/CardStyles.bs'
 
 export default {
-  title: "Textarea",
-};
+    title: 'Textarea',
+}
 
 const margin = {
-  margin: "1rem",
-};
+    margin: '1rem',
+}
 
 export const textarea = () => {
-  const theme = useDarkMode() ? dark : light;
+    const theme = useDarkMode() ? dark : light
 
-  return (
-    <div style={margin}>
-      <Card theme={theme}>
-        <h1>Textarea</h1>
+    return (
+        <div style={margin}>
+            <Card theme={theme}>
+                <h1>Textarea</h1>
 
-        <h3>Interface</h3>
-        <p>
-          As there is the option to have a label, we need to have an id so that
-          we can make that clickable and link the label and the input. We can
-          infer the id from the label, but this may clash. When in doubt, add an
-          id.
-        </p>
-        <SyntaxHighlighter language="reason" style={okaidia} showLineNumbers>
-          {`type Textarea: (
+                <h3>Interface</h3>
+                <p>
+                    As there is the option to have a label, we need to have an
+                    id so that we can make that clickable and link the label and
+                    the input. We can infer the id from the label, but this may
+                    clash. When in doubt, add an id.
+                </p>
+                <SyntaxHighlighter
+                    language="reason"
+                    style={okaidia}
+                    showLineNumbers
+                >
+                    {`type Textarea: (
   ~_type: option(string), /* maps to "type", defaults to "text" */
   ~defaultValue: option(string), /* defaults to empty string */
   ~value: option(string),
   ~disabled: option(bool), /* defaults to false */
-  ~label: option(UiStyles.labels), /* defaults to "UiStyles.Unlabeled" */
+  ~label: option(UiTypes.labels), /* defaults to "UiTypes.Unlabeled" */
   ~id: option(string), /* the id is used to make labels clickable. This falls back to the label */
-  ~validity: option(UiStyles.validation), /* defaults to "UiStyles.Valid" */
+  ~validity: option(UiTypes.validation), /* defaults to "UiTypes.Valid" */
+  ~variant: option(UiTypes.fontStyle), /* defaults to "UiTypes.Normal" */
   ~width: option(float), /* as a percentage. Defaults to "100.0" */
   ~resize=option(TextareaStyles.resize), /* Defauls to NoResize */
   ~theme: option(UiTypes.theme)
@@ -59,105 +64,105 @@ export const textarea = () => {
   ~cols=option(int), /* Defaults to 50 rows */
 ) => React.element;
 `}
-        </SyntaxHighlighter>
+                </SyntaxHighlighter>
 
-        <h3>Preview</h3>
-        <h4>Custom Width</h4>
-        <p>Sizing can either be done via the 'Width' attribute.</p>
-        <Textarea
-          label={labeled("I'm a tiny input")}
-          placeholder="Like for a zipcode"
-          width={10.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Textarea
-          label={labeled("I'm a bit bigger")}
-          placeholder="Like for a name"
-          width={60.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Textarea
-          label={labeled("If the total width stays under 100%")}
-          placeholder="We stay inline"
-          width={30.0}
-          theme={theme}
-          variant={normal}
-        />
-        <h4>Custom Height</h4>
-        <Textarea
-          label={labeled("I'm not that tall")}
-          placeholder="Only 2 rows"
-          width={50}
-          rows={2}
-          theme={theme}
-          variant={normal}
-        />
-        <Textarea
-          label={labeled("I'm a bit bigger")}
-          placeholder="10 rows for me"
-          width={50}
-          rows={10}
-          theme={theme}
-          variant={normal}
-        />
-        <h4>Labeled vs Unlabeled</h4>
-        <Textarea
-          label={labeled("I have a label")}
-          placeholder="Check my cool label above"
-          width={50.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Textarea
-          placeholder="I don't"
-          width={50.0}
-          theme={theme}
-          variant={normal}
-        />
+                <h3>Preview</h3>
+                <h4>Custom Width</h4>
+                <p>Sizing can either be done via the 'Width' attribute.</p>
+                <Textarea
+                    label={labeled("I'm a tiny input")}
+                    placeholder="Like for a zipcode"
+                    width={10.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Textarea
+                    label={labeled("I'm a bit bigger")}
+                    placeholder="Like for a name"
+                    width={60.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Textarea
+                    label={labeled('If the total width stays under 100%')}
+                    placeholder="We stay inline"
+                    width={30.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <h4>Custom Height</h4>
+                <Textarea
+                    label={labeled("I'm not that tall")}
+                    placeholder="Only 2 rows"
+                    width={50}
+                    rows={2}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Textarea
+                    label={labeled("I'm a bit bigger")}
+                    placeholder="10 rows for me"
+                    width={50}
+                    rows={10}
+                    theme={theme}
+                    variant={normal}
+                />
+                <h4>Labeled vs Unlabeled</h4>
+                <Textarea
+                    label={labeled('I have a label')}
+                    placeholder="Check my cool label above"
+                    width={50.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Textarea
+                    placeholder="I don't"
+                    width={50.0}
+                    theme={theme}
+                    variant={normal}
+                />
 
-        <h4>Normal / Mono fonts</h4>
-        <Textarea
-          label={labeled("Normal Font")}
-          placeholder="Font setting will also have effect in the placeholder"
-          width={50.0}
-          theme={theme}
-          variant={normal}
-        />
-        <Textarea
-          label={labeled("Mono Font")}
-          placeholder="And in the label"
-          width={50.0}
-          theme={theme}
-          variant={mono}
-        />
+                <h4>Normal / Mono fonts</h4>
+                <Textarea
+                    label={labeled('Normal Font')}
+                    placeholder="Font setting will also have effect in the placeholder"
+                    width={50.0}
+                    theme={theme}
+                    variant={normal}
+                />
+                <Textarea
+                    label={labeled('Mono Font')}
+                    placeholder="And in the label"
+                    width={50.0}
+                    theme={theme}
+                    variant={mono}
+                />
 
-        <h4>Resizeable</h4>
-        <Textarea
-          label={labeled("I'm not resizable")}
-          placeholder="Neither horizontally nor vertically"
-          theme={theme}
-        />
-        <Textarea
-          label={labeled("I can resize")}
-          placeholder="Horizontally only"
-          resize={horizontal}
-          theme={theme}
-        />
-        <Textarea
-          label={labeled("I can resize")}
-          placeholder="Vertically only"
-          resize={vertical}
-          theme={theme}
-        />
-        <Textarea
-          label={labeled("I can resize")}
-          placeholder="All the ways"
-          resize={both}
-          theme={theme}
-        />
-      </Card>
-    </div>
-  );
-};
+                <h4>Resizeable</h4>
+                <Textarea
+                    label={labeled("I'm not resizable")}
+                    placeholder="Neither horizontally nor vertically"
+                    theme={theme}
+                />
+                <Textarea
+                    label={labeled('I can resize')}
+                    placeholder="Horizontally only"
+                    resize={horizontal}
+                    theme={theme}
+                />
+                <Textarea
+                    label={labeled('I can resize')}
+                    placeholder="Vertically only"
+                    resize={vertical}
+                    theme={theme}
+                />
+                <Textarea
+                    label={labeled('I can resize')}
+                    placeholder="All the ways"
+                    resize={both}
+                    theme={theme}
+                />
+            </Card>
+        </div>
+    )
+}


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description
This touches up the docs a little bit;
- `UiStyles` -> `UiTypes` (typo)
- Add `variant` to input / textarea

Also pins browserlist because of CVE-2021-23364 .


###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit